### PR TITLE
feat(api): Add Swagger/OpenAPI documentation for all Taskify REST APIs

### DIFF
--- a/concept/apps/api/package.json
+++ b/concept/apps/api/package.json
@@ -12,7 +12,9 @@
     "pg": "^8.13.0",
     "cors": "^2.8.5",
     "@azure/identity": "^4.5.0",
-    "@azure/keyvault-secrets": "^4.9.0"
+    "@azure/keyvault-secrets": "^4.9.0",
+    "swagger-jsdoc": "^6.2.8",
+    "swagger-ui-express": "^5.0.1"
   },
   "devDependencies": {
     "nodemon": "^3.1.0"

--- a/concept/apps/api/src/index.js
+++ b/concept/apps/api/src/index.js
@@ -18,6 +18,8 @@
 
 const express = require("express");
 const cors = require("cors");
+const swaggerUi = require("swagger-ui-express");
+const swaggerSpec = require("./swagger");
 const { initializePool } = require("./services/database");
 const { errorHandler } = require("./middleware/errorHandler");
 const usersRouter = require("./routes/users");
@@ -46,6 +48,41 @@ async function start() {
   // ---------------------------------------------------------------------------
   // Health Check
   // ---------------------------------------------------------------------------
+  /**
+   * @openapi
+   * /health:
+   *   get:
+   *     tags: [Health]
+   *     summary: API health check
+   *     description: Returns the API and database connection status.
+   *     responses:
+   *       200:
+   *         description: API and database are healthy.
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 status:
+   *                   type: string
+   *                   example: ok
+   *                 database:
+   *                   type: string
+   *                   example: connected
+   *       503:
+   *         description: Database connection is unavailable.
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 status:
+   *                   type: string
+   *                   example: error
+   *                 database:
+   *                   type: string
+   *                   example: disconnected
+   */
   app.get("/api/health", async (req, res) => {
     try {
       const { getPool } = require("./services/database");
@@ -54,6 +91,17 @@ async function start() {
     } catch {
       res.status(503).json({ status: "error", database: "disconnected" });
     }
+  });
+
+  // ---------------------------------------------------------------------------
+  // Swagger UI
+  // ---------------------------------------------------------------------------
+  app.use("/api/docs", swaggerUi.serve, swaggerUi.setup(swaggerSpec, {
+    customSiteTitle: "Taskify API Docs",
+  }));
+  app.get("/api/docs.json", (req, res) => {
+    res.setHeader("Content-Type", "application/json");
+    res.send(swaggerSpec);
   });
 
   // ---------------------------------------------------------------------------
@@ -75,6 +123,7 @@ async function start() {
   app.listen(PORT, "0.0.0.0", () => {
     console.log(`Taskify API listening on port ${PORT}`);
     console.log(`Health check: http://localhost:${PORT}/api/health`);
+    console.log(`Swagger UI:   http://localhost:${PORT}/api/docs`);
   });
 }
 

--- a/concept/apps/api/src/routes/comments.js
+++ b/concept/apps/api/src/routes/comments.js
@@ -17,10 +17,29 @@ const { createError } = require("../middleware/errorHandler");
 const router = Router();
 
 /**
- * GET /api/tasks/:taskId/comments
- * Returns all comments for a task, ordered by creation time.
- * Includes author details via JOIN. Threading is handled client-side
- * using parent_comment_id.
+ * @openapi
+ * /tasks/{taskId}/comments:
+ *   get:
+ *     tags: [Comments]
+ *     summary: List comments for a task
+ *     description: Returns all comments for a task ordered by creation time (oldest first). Includes author details. Threading is resolved client-side via `parent_comment_id`.
+ *     parameters:
+ *       - in: path
+ *         name: taskId
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *         description: The task UUID.
+ *     responses:
+ *       200:
+ *         description: Array of comments.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/Comment'
  */
 router.get("/tasks/:taskId/comments", async (req, res, next) => {
   try {
@@ -43,10 +62,50 @@ router.get("/tasks/:taskId/comments", async (req, res, next) => {
 });
 
 /**
- * POST /api/tasks/:taskId/comments
- * Creates a new comment on a task. Requires { content } in body.
- * Optional: parent_comment_id for threading.
- * Requires X-User-Id header for author identification.
+ * @openapi
+ * /tasks/{taskId}/comments:
+ *   post:
+ *     tags: [Comments]
+ *     summary: Add a comment to a task
+ *     description: Creates a new comment on a task. `X-User-Id` header identifies the author.
+ *     parameters:
+ *       - in: path
+ *         name: taskId
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *         description: The task UUID.
+ *       - $ref: '#/components/parameters/XUserId'
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [content]
+ *             properties:
+ *               content:
+ *                 type: string
+ *                 example: "Looks good to me!"
+ *               parent_comment_id:
+ *                 type: string
+ *                 format: uuid
+ *                 nullable: true
+ *                 description: Set to thread this as a reply.
+ *     responses:
+ *       201:
+ *         description: Comment created.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Comment'
+ *       400:
+ *         description: Missing content or X-User-Id header.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
  */
 router.post("/tasks/:taskId/comments", async (req, res, next) => {
   try {
@@ -87,9 +146,57 @@ router.post("/tasks/:taskId/comments", async (req, res, next) => {
 });
 
 /**
- * PUT /api/comments/:id
- * Edits a comment. Only the original author (matched by X-User-Id) can edit.
- * Requires { content } in body.
+ * @openapi
+ * /comments/{id}:
+ *   put:
+ *     tags: [Comments]
+ *     summary: Edit a comment
+ *     description: Updates the content of a comment. Only the original author (identified via `X-User-Id`) may edit.
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *         description: The comment UUID.
+ *       - $ref: '#/components/parameters/XUserId'
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [content]
+ *             properties:
+ *               content:
+ *                 type: string
+ *                 example: "Updated comment text"
+ *     responses:
+ *       200:
+ *         description: Updated comment.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Comment'
+ *       400:
+ *         description: Missing content or X-User-Id header.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       403:
+ *         description: Caller is not the comment author.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       404:
+ *         description: Comment not found.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
  */
 router.put("/comments/:id", async (req, res, next) => {
   try {
@@ -144,9 +251,53 @@ router.put("/comments/:id", async (req, res, next) => {
 });
 
 /**
- * DELETE /api/comments/:id
- * Deletes a comment. Only the original author (matched by X-User-Id) can delete.
- * Child comments are also deleted via CASCADE.
+ * @openapi
+ * /comments/{id}:
+ *   delete:
+ *     tags: [Comments]
+ *     summary: Delete a comment
+ *     description: Deletes a comment. Only the original author (identified via `X-User-Id`) may delete. Child (threaded) comments are also deleted via CASCADE.
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *         description: The comment UUID.
+ *       - $ref: '#/components/parameters/XUserId'
+ *     responses:
+ *       200:
+ *         description: Comment deleted.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Comment deleted
+ *                 id:
+ *                   type: string
+ *                   format: uuid
+ *       400:
+ *         description: Missing X-User-Id header.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       403:
+ *         description: Caller is not the comment author.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       404:
+ *         description: Comment not found.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
  */
 router.delete("/comments/:id", async (req, res, next) => {
   try {

--- a/concept/apps/api/src/routes/projects.js
+++ b/concept/apps/api/src/routes/projects.js
@@ -13,8 +13,21 @@ const { createError } = require("../middleware/errorHandler");
 const router = Router();
 
 /**
- * GET /api/projects
- * Returns all projects with task count per status.
+ * @openapi
+ * /projects:
+ *   get:
+ *     tags: [Projects]
+ *     summary: List all projects
+ *     description: Returns all projects with total and completed task counts, ordered by creation date (newest first).
+ *     responses:
+ *       200:
+ *         description: Array of projects.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/Project'
  */
 router.get("/", async (req, res, next) => {
   try {
@@ -35,8 +48,33 @@ router.get("/", async (req, res, next) => {
 });
 
 /**
- * GET /api/projects/:id
- * Returns a single project with its tasks grouped by status.
+ * @openapi
+ * /projects/{id}:
+ *   get:
+ *     tags: [Projects]
+ *     summary: Get a project by ID
+ *     description: Returns a single project by its UUID.
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *         description: The project UUID.
+ *     responses:
+ *       200:
+ *         description: The requested project.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Project'
+ *       404:
+ *         description: Project not found.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
  */
 router.get("/:id", async (req, res, next) => {
   try {
@@ -54,8 +92,39 @@ router.get("/:id", async (req, res, next) => {
 });
 
 /**
- * POST /api/projects
- * Creates a new project. Requires { name } in request body.
+ * @openapi
+ * /projects:
+ *   post:
+ *     tags: [Projects]
+ *     summary: Create a project
+ *     description: Creates a new project. `name` is required.
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [name]
+ *             properties:
+ *               name:
+ *                 type: string
+ *                 example: "Website Redesign"
+ *               description:
+ *                 type: string
+ *                 example: "Full redesign of the company website"
+ *     responses:
+ *       201:
+ *         description: Project created successfully.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Project'
+ *       400:
+ *         description: Missing or invalid request body.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
  */
 router.post("/", async (req, res, next) => {
   try {

--- a/concept/apps/api/src/routes/tasks.js
+++ b/concept/apps/api/src/routes/tasks.js
@@ -18,9 +18,29 @@ const router = Router();
 const VALID_STATUSES = ["todo", "in_progress", "in_review", "done"];
 
 /**
- * GET /api/projects/:projectId/tasks
- * Returns all tasks for a project, ordered by status and position.
- * Includes assigned user details via LEFT JOIN.
+ * @openapi
+ * /projects/{projectId}/tasks:
+ *   get:
+ *     tags: [Tasks]
+ *     summary: List tasks for a project
+ *     description: Returns all tasks in a project ordered by position and creation date. Includes assigned user details.
+ *     parameters:
+ *       - in: path
+ *         name: projectId
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *         description: The project UUID.
+ *     responses:
+ *       200:
+ *         description: Array of tasks.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/Task'
  */
 router.get("/projects/:projectId/tasks", async (req, res, next) => {
   try {
@@ -44,9 +64,51 @@ router.get("/projects/:projectId/tasks", async (req, res, next) => {
 });
 
 /**
- * POST /api/projects/:projectId/tasks
- * Creates a new task. Requires { title } in body.
- * Optional: description, assigned_user_id.
+ * @openapi
+ * /projects/{projectId}/tasks:
+ *   post:
+ *     tags: [Tasks]
+ *     summary: Create a task in a project
+ *     description: Creates a new task placed at the end of the `todo` column.
+ *     parameters:
+ *       - in: path
+ *         name: projectId
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *         description: The project UUID.
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [title]
+ *             properties:
+ *               title:
+ *                 type: string
+ *                 example: "Implement login page"
+ *               description:
+ *                 type: string
+ *                 example: "Build the login page UI and hook up auth"
+ *               assigned_user_id:
+ *                 type: string
+ *                 format: uuid
+ *                 nullable: true
+ *     responses:
+ *       201:
+ *         description: Task created successfully.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Task'
+ *       400:
+ *         description: Validation error.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
  */
 router.post("/projects/:projectId/tasks", async (req, res, next) => {
   try {
@@ -86,8 +148,53 @@ router.post("/projects/:projectId/tasks", async (req, res, next) => {
 });
 
 /**
- * PUT /api/tasks/:id
- * Updates a task's title and/or description.
+ * @openapi
+ * /tasks/{id}:
+ *   put:
+ *     tags: [Tasks]
+ *     summary: Update a task
+ *     description: Updates a task's `title` and/or `description`.
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *         description: The task UUID.
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [title]
+ *             properties:
+ *               title:
+ *                 type: string
+ *                 example: "Implement login page"
+ *               description:
+ *                 type: string
+ *                 example: "Build the login page UI and hook up auth"
+ *     responses:
+ *       200:
+ *         description: Updated task.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Task'
+ *       400:
+ *         description: Validation error.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       404:
+ *         description: Task not found.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
  */
 router.put("/tasks/:id", async (req, res, next) => {
   try {
@@ -124,9 +231,55 @@ router.put("/tasks/:id", async (req, res, next) => {
 });
 
 /**
- * PATCH /api/tasks/:id/status
- * Changes task status and position (used by Kanban drag-and-drop).
- * Requires { status, position } in body.
+ * @openapi
+ * /tasks/{id}/status:
+ *   patch:
+ *     tags: [Tasks]
+ *     summary: Change task status
+ *     description: Updates the status and position of a task. Used by the Kanban drag-and-drop feature.
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *         description: The task UUID.
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [status, position]
+ *             properties:
+ *               status:
+ *                 type: string
+ *                 enum: [todo, in_progress, in_review, done]
+ *                 example: in_progress
+ *               position:
+ *                 type: integer
+ *                 minimum: 0
+ *                 example: 2
+ *     responses:
+ *       200:
+ *         description: Updated task.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Task'
+ *       400:
+ *         description: Validation error (invalid status or missing position).
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       404:
+ *         description: Task not found.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
  */
 router.patch("/tasks/:id/status", async (req, res, next) => {
   try {
@@ -170,9 +323,45 @@ router.patch("/tasks/:id/status", async (req, res, next) => {
 });
 
 /**
- * PATCH /api/tasks/:id/assign
- * Assigns or unassigns a user to a task.
- * Requires { assigned_user_id } in body (null to unassign).
+ * @openapi
+ * /tasks/{id}/assign:
+ *   patch:
+ *     tags: [Tasks]
+ *     summary: Assign or unassign a user
+ *     description: Assigns a user to a task. Send `null` for `assigned_user_id` to unassign.
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *         description: The task UUID.
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               assigned_user_id:
+ *                 type: string
+ *                 format: uuid
+ *                 nullable: true
+ *                 example: "3f1d2c4a-5678-90ab-cdef-1234567890ab"
+ *     responses:
+ *       200:
+ *         description: Updated task.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Task'
+ *       404:
+ *         description: Task not found.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
  */
 router.patch("/tasks/:id/assign", async (req, res, next) => {
   try {
@@ -206,8 +395,40 @@ router.patch("/tasks/:id/assign", async (req, res, next) => {
 });
 
 /**
- * DELETE /api/tasks/:id
- * Deletes a task and its associated comments (via CASCADE).
+ * @openapi
+ * /tasks/{id}:
+ *   delete:
+ *     tags: [Tasks]
+ *     summary: Delete a task
+ *     description: Deletes a task and all its associated comments (via CASCADE).
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *         description: The task UUID.
+ *     responses:
+ *       200:
+ *         description: Task deleted.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Task deleted
+ *                 id:
+ *                   type: string
+ *                   format: uuid
+ *       404:
+ *         description: Task not found.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
  */
 router.delete("/tasks/:id", async (req, res, next) => {
   try {

--- a/concept/apps/api/src/routes/users.js
+++ b/concept/apps/api/src/routes/users.js
@@ -12,8 +12,21 @@ const { createError } = require("../middleware/errorHandler");
 const router = Router();
 
 /**
- * GET /api/users
- * Returns all users ordered by name.
+ * @openapi
+ * /users:
+ *   get:
+ *     tags: [Users]
+ *     summary: List all users
+ *     description: Returns all users ordered alphabetically by name.
+ *     responses:
+ *       200:
+ *         description: Array of users.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/User'
  */
 router.get("/", async (req, res, next) => {
   try {
@@ -27,8 +40,33 @@ router.get("/", async (req, res, next) => {
 });
 
 /**
- * GET /api/users/:id
- * Returns a single user by UUID.
+ * @openapi
+ * /users/{id}:
+ *   get:
+ *     tags: [Users]
+ *     summary: Get a user by ID
+ *     description: Returns a single user by their UUID.
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *         description: The user UUID.
+ *     responses:
+ *       200:
+ *         description: The requested user.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/User'
+ *       404:
+ *         description: User not found.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
  */
 router.get("/:id", async (req, res, next) => {
   try {

--- a/concept/apps/api/src/swagger.js
+++ b/concept/apps/api/src/swagger.js
@@ -1,0 +1,134 @@
+// =============================================================================
+// Swagger / OpenAPI Configuration
+// =============================================================================
+// Generates the OpenAPI 3.0 spec from JSDoc annotations across all route files.
+// Served at /api/docs (UI) and /api/docs.json (raw spec).
+// =============================================================================
+
+const swaggerJsdoc = require("swagger-jsdoc");
+const path = require("path");
+
+const options = {
+  definition: {
+    openapi: "3.0.0",
+    info: {
+      title: "Taskify API",
+      version: "1.0.0",
+      description:
+        "REST API for the Taskify Kanban board application. Manage projects, tasks, users, and comments.",
+      contact: {
+        name: "Taskify Team",
+      },
+    },
+    servers: [
+      {
+        url: "/api",
+        description: "API base path",
+      },
+    ],
+    components: {
+      parameters: {
+        XUserId: {
+          in: "header",
+          name: "X-User-Id",
+          schema: { type: "string", format: "uuid" },
+          required: true,
+          description: "UUID of the acting user (used for comment authorship).",
+        },
+      },
+      schemas: {
+        Error: {
+          type: "object",
+          properties: {
+            error: {
+              type: "object",
+              properties: {
+                status: { type: "integer", example: 400 },
+                message: { type: "string", example: "Validation failed" },
+              },
+            },
+          },
+        },
+        User: {
+          type: "object",
+          properties: {
+            id: { type: "string", format: "uuid" },
+            name: { type: "string", example: "Alice" },
+            role: { type: "string", example: "developer" },
+            avatar_color: { type: "string", example: "#4A90D9" },
+            created_at: { type: "string", format: "date-time" },
+          },
+        },
+        Project: {
+          type: "object",
+          properties: {
+            id: { type: "string", format: "uuid" },
+            name: { type: "string", example: "Website Redesign" },
+            description: { type: "string", example: "Full redesign of the company website" },
+            task_count: { type: "integer", example: 12 },
+            done_count: { type: "integer", example: 5 },
+            created_at: { type: "string", format: "date-time" },
+            updated_at: { type: "string", format: "date-time" },
+          },
+        },
+        Task: {
+          type: "object",
+          properties: {
+            id: { type: "string", format: "uuid" },
+            project_id: { type: "string", format: "uuid" },
+            title: { type: "string", example: "Implement login page" },
+            description: { type: "string", example: "Build the login page UI and hook up auth" },
+            status: {
+              type: "string",
+              enum: ["todo", "in_progress", "in_review", "done"],
+              example: "todo",
+            },
+            position: { type: "integer", example: 0 },
+            assigned_user_id: { type: "string", format: "uuid", nullable: true },
+            assigned_user_name: { type: "string", nullable: true, example: "Alice" },
+            assigned_user_avatar_color: { type: "string", nullable: true, example: "#4A90D9" },
+            parent_task_id: { type: "string", format: "uuid", nullable: true },
+            created_at: { type: "string", format: "date-time" },
+            updated_at: { type: "string", format: "date-time" },
+          },
+        },
+        Comment: {
+          type: "object",
+          properties: {
+            id: { type: "string", format: "uuid" },
+            task_id: { type: "string", format: "uuid" },
+            user_id: { type: "string", format: "uuid" },
+            parent_comment_id: { type: "string", format: "uuid", nullable: true },
+            content: { type: "string", example: "Looks good to me!" },
+            author_name: { type: "string", example: "Alice" },
+            author_avatar_color: { type: "string", example: "#4A90D9" },
+            created_at: { type: "string", format: "date-time" },
+            updated_at: { type: "string", format: "date-time" },
+          },
+        },
+        TaskJob: {
+          type: "object",
+          properties: {
+            id: { type: "string", format: "uuid" },
+            task_id: { type: "string", format: "uuid" },
+            project_id: { type: "string", format: "uuid" },
+            job_type: { type: "string", example: "decompose" },
+            status: {
+              type: "string",
+              enum: ["pending", "running", "completed", "failed"],
+              example: "pending",
+            },
+            created_at: { type: "string", format: "date-time" },
+            updated_at: { type: "string", format: "date-time" },
+          },
+        },
+      },
+    },
+  },
+  apis: [
+    path.join(__dirname, "routes", "*.js"),
+    path.join(__dirname, "index.js"),
+  ],
+};
+
+module.exports = swaggerJsdoc(options);


### PR DESCRIPTION
## Summary

Adds interactive Swagger UI documentation for all Taskify REST API endpoints, served at `/api/docs`.

## Changes

### New file: `concept/apps/api/src/swagger.js`
- OpenAPI 3.0 spec configuration using `swagger-jsdoc`
- Reusable component schemas: `User`, `Project`, `Task`, `Comment`, `TaskJob`, `Error`
- Shared parameter: `X-User-Id` header

### Updated: `concept/apps/api/package.json`
- Added `swagger-jsdoc` and `swagger-ui-express` dependencies

### Updated: `concept/apps/api/src/index.js`
- Mounts Swagger UI at `GET /api/docs`
- Serves raw OpenAPI JSON spec at `GET /api/docs.json`

### Updated: all route files
Each route now has a full `@openapi` JSDoc annotation covering path params, request body, and all response codes.

## Endpoints documented (16 total)

| Method | Path | Tag |
|--------|------|-----|
| GET | `/api/health` | Health |
| GET | `/api/users` | Users |
| GET | `/api/users/:id` | Users |
| GET | `/api/projects` | Projects |
| GET | `/api/projects/:id` | Projects |
| POST | `/api/projects` | Projects |
| GET | `/api/projects/:projectId/tasks` | Tasks |
| POST | `/api/projects/:projectId/tasks` | Tasks |
| PUT | `/api/tasks/:id` | Tasks |
| PATCH | `/api/tasks/:id/status` | Tasks |
| PATCH | `/api/tasks/:id/assign` | Tasks |
| DELETE | `/api/tasks/:id` | Tasks |
| GET | `/api/tasks/:taskId/comments` | Comments |
| POST | `/api/tasks/:taskId/comments` | Comments |
| PUT | `/api/comments/:id` | Comments |
| DELETE | `/api/comments/:id` | Comments |

## How to access

After running `npm install` in `concept/apps/api`:
- **Swagger UI**: http://localhost:3000/api/docs
- **Raw OpenAPI spec**: http://localhost:3000/api/docs.json